### PR TITLE
Per issue #29 - Adding "id" field to credentialStatus in example

### DIFF
--- a/index.html
+++ b/index.html
@@ -378,7 +378,7 @@ includes the <code>StatusList2021Credential</code> value.
   "issuer": "did:example:12345",
   "issued": "2021-04-05T14:27:42Z",
   <span class="highlight">"credentialStatus": {
-    "id": "https://example.com/status/3#list"
+    "id": "https://example.com/credentials/status/3#94567"
     "type": "StatusList2021Entry",
     "statusPurpose": "revocation",
     "statusListIndex": "94567",

--- a/index.html
+++ b/index.html
@@ -378,6 +378,7 @@ includes the <code>StatusList2021Credential</code> value.
   "issuer": "did:example:12345",
   "issued": "2021-04-05T14:27:42Z",
   <span class="highlight">"credentialStatus": {
+    "id": "https://example.com/status/3#list"
     "type": "StatusList2021Entry",
     "statusPurpose": "revocation",
     "statusListIndex": "94567",


### PR DESCRIPTION
Referencing this issue: https://github.com/w3c-ccg/vc-status-list-2021/issues/29

The example was a little misleading with the missing "id" field, adding it with this change.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: connect ETIMEDOUT 140.82.113.6:443 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 13, 2022, 7:51 PM UTC)_.

<details>
<summary>More</summary>







_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c-ccg/vc-status-list-2021%2330.)._
</details>
