### PR TITLE
fix: credentialStatus

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,8 +287,8 @@ The following sections outlines the data model for this document.
 
         <p>
 When an <a>issuer</a> desires to enable status information for a
-<a>verifiable credential</a>, they MAY add a <code>status</code> property
-that uses the data model described in this specification.
+<a>verifiable credential</a>, they MAY add a <code>credentialStatus</code> 
+property that uses the data model described in this specification.
         </p>
 
         <table class="simple">


### PR DESCRIPTION
The property is called `credentialStatus`, not `status`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nissimsan/vc-status-list-2021/pull/34.html" title="Last updated on Nov 22, 2022, 9:47 AM UTC (705d8cb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-status-list-2021/34/c70e59f...nissimsan:705d8cb.html" title="Last updated on Nov 22, 2022, 9:47 AM UTC (705d8cb)">Diff</a>